### PR TITLE
Link Roku on Web project to Figma presentation

### DIFF
--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -31,7 +31,7 @@ export default function Index() {
   };
 
   const projects = [
-    { title: "Roku on Web", category: "Roku", tags: ["Mobile", "Web UX"], href: "/projects/Roku Launchpad.pdf", image: "/images/Roku Web.png", passcode: "1994" },
+    { title: "Roku on Web", category: "Roku", tags: ["Mobile", "Web UX"], href: "https://www.figma.com/deck/3isRZVBdJ5FOfNG6gvwLEW/Roku-on-Web-UX?node-id=3-116&viewport=-95%2C-40%2C0.46&t=VBzkeED6AYS6gocb-1&scaling=min-zoom&content-scaling=fixed&page-id=0%3A1", image: "/images/Roku Web.png", passcode: "1994" },
     { title: "Roku Search Feeds", category: "Roku", tags: ["Web portal", "B2B UX"], href: "/projects/Search feed.pdf", image: "/images/Search feed.png" },
     { title: "Roku Developers", category: "Roku", tags: ["Web portal", "Branding"], href: "/projects/Roku.pdf", image: "/images/Launchpad.png" },
     { title: "Cyber Risk Analysis", category: "Guidewire", tags: ["Dashboards", "Data visualization"], href: "/projects/GW_Cyence.pdf", image: "/images/Cyence.png" },


### PR DESCRIPTION
## Summary
- Replace the local PDF link for the **Roku on Web** project card with the Figma deck URL
- The card now opens the interactive Figma presentation instead of a static PDF

## What changed
`client/pages/Index.tsx`: Updated the `href` for the "Roku on Web" project from `/projects/Roku Launchpad.pdf` to the Figma deck URL. The passcode gate (`1994`) remains unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)